### PR TITLE
Missing comma

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "grunt-contrib-uglify": "~0.2.7",
     "grunt-concurrent": "~0.4.2",
     "grunt-coffeelint": "0.0.8",
-    "grunt-contrib-concat": "~0.3.0"
+    "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-cssmin": "~1.0.0"  
   },
   "optionalDependencies": {},


### PR DESCRIPTION
From package.json, line 21 was missing a comma. `npm install` failed because of that.